### PR TITLE
Declare Kiwi as a tests target dependency

### DIFF
--- a/SampleProject/Podfile
+++ b/SampleProject/Podfile
@@ -1,2 +1,6 @@
 platform :ios, :deployment_target => "5.0"
-dependency 'Kiwi'
+
+target :test, :exclusive => true do
+  link_with 'SampleProjectTests'
+  pod 'Kiwi'
+end


### PR DESCRIPTION
This should fix the issue of SampleProjectTests not being able to compile because Kiwi.h could not be found. Before, the SampleProjectTests target did not have Pods in its header search path. There are basically two ways (that I know of) to resolve this: either manually add the paths to the SampleProjectTests target's Header Search Path, or declare Kiwi as a test target dependency. I think the latter better expresses the intent of the Kiwi dependency.

This was tested against CocoaPods 0.8.0. The change also updates the dependency declaration using `pod` syntax added in [version 0.8.0](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md#080).

Also, you'll have to run `pod install` after this update.
