### PR TITLE
Made some really small changes to the codebase

### DIFF
--- a/src/CoreDataManager.m
+++ b/src/CoreDataManager.m
@@ -16,15 +16,13 @@ static NSString *CUSTOM_DATABASE_NAME = nil;
 @synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
 
 static CoreDataManager *singleton;
-- (id)initForSingleton {
-    return [super init];
-}
 
 + (id)instance {
-    @synchronized(self) {
-        if (!singleton)
-            singleton = [[self alloc] initForSingleton];
-    }
+    static dispatch_once_t singletonToken;
+    dispatch_once(&singletonToken, ^{
+        singleton = [[self alloc] init];
+    });
+    
     return singleton;
 }
 


### PR DESCRIPTION
Changes:
- The singleton creation now uses a dispatch_once_t token, which is a bit faster and safer than the @synchronized(self) {} version
- whereFormat: now creates a predicate directly instead of an intermediate string (NSPredicate and NSString have a slightly different format interpreter)
- predicateFromStringOrDict: doesn't double evaluate the format string anymore.

Not sure if you want to pull them over, but I thought you might be interested.
