### PR TITLE
Change custom model and database name to instance methods

### DIFF
--- a/src/CoreDataManager.h
+++ b/src/CoreDataManager.h
@@ -15,6 +15,8 @@
 @property (readonly, strong, nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (readonly, strong, nonatomic) NSManagedObjectModel *managedObjectModel;
 @property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@property (copy, nonatomic) NSString *databaseName;
+@property (copy, nonatomic) NSString *modelName;
 
 + (id)instance;
 - (BOOL)saveContext;

--- a/src/CoreDataManager.m
+++ b/src/CoreDataManager.m
@@ -7,13 +7,13 @@
 //
 
 #import "CoreDataManager.h"
-static NSString *CUSTOM_MODEL_NAME = nil;
-static NSString *CUSTOM_DATABASE_NAME = nil;
 
 @implementation CoreDataManager
 @synthesize managedObjectContext = _managedObjectContext;
 @synthesize managedObjectModel = _managedObjectModel;
 @synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
+@synthesize databaseName = _databaseName;
+@synthesize modelName = _modelName;
 
 static CoreDataManager *singleton;
 - (id)initForSingleton {
@@ -36,13 +36,15 @@ static CoreDataManager *singleton;
 }
 
 - (NSString *)databaseName {
-    if (CUSTOM_DATABASE_NAME) return CUSTOM_DATABASE_NAME;
-    return [[self appName] stringByAppendingString:@".sqlite"];
+    if (_databaseName != nil) return _databaseName;
+    _databaseName = [[[self appName] stringByAppendingString:@".sqlite"] copy];
+    return _databaseName;
 }
 
 - (NSString *)modelName {
-    if (CUSTOM_MODEL_NAME) return CUSTOM_MODEL_NAME;
-    return [self appName];
+    if (_modelName != nil) return _modelName;
+    _modelName = [[self appName] copy];
+    return _modelName;
 }
 
 #pragma mark - Public


### PR DESCRIPTION
The custom database and model name constants require modifying the source files of the library in place, which doesn't work with CocoaPods as the library should be able to be deleted and downloaded from the server again without affecting the project.

This change converts `CUSTOM_MODEL_NAME` and `CUSTOM_DATABASE_NAME` to instance variables.
