### PR TITLE
NSLog a message when NSManagedObject Class's name is not as same as the entity's name in the CoreData Model.

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -142,6 +142,9 @@
     NSFetchRequest *request = [NSFetchRequest new];
     NSEntityDescription *entity = [NSEntityDescription entityForName:[self entityName]
                                               inManagedObjectContext:context];
+
+    if (entity == nil) NSLog(@"There's no entity named \"%@\" in your CoreData model. Please confirm the %@ class's name is as same as the related entity in your model. Or you can set the entity name by using \"+ (NSString *)entityName\" in your subclass.",[self entityName],[self entityName]);
+    
     [request setEntity:entity];
     return request;
 }


### PR DESCRIPTION
I have a subclass of NSManageObject which have a prefix in the Class name, and an entity without the prefix in the CoreData Model. So when I try to run it, it crash, and I had no idea why is not working. The README do not have any clues about entity name, And I just simply forgot them.

This is a tiny NSLog when an NSEntityDescription object is nil. So we can figure out what's had happen when we meet the same problem as I do.
