### PR TITLE
fixed a crash with quotes in strings in query dictionaries

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -146,7 +146,7 @@
         return [NSPredicate predicateWithFormat:condition];
     
     else if ([condition isKindOfClass:[NSDictionary class]])
-        return [NSPredicate predicateWithFormat:[self queryStringFromDictionary:condition] argumentArray:[(NSDictionary *)condition allKeys]];
+        return [NSPredicate predicateWithFormat:[self queryStringFromDictionary:condition] argumentArray:[(NSDictionary *)condition allValues]];
     
     return nil;
 }


### PR DESCRIPTION
Reproducible with such code:

```
[Model where:@{ @"prop": @"it doesn't work" }]
```

The reason for the crash is that queryStringFromDictionary doesn't escape any quotes in passed arguments, my patch fixes this.
