### PR TITLE
Fixed whereFormat issue

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -40,10 +40,10 @@
 + (NSArray *)whereFormat:(NSString *)format, ... {
     va_list va_arguments;
     va_start(va_arguments, format);
-    NSString *condition = [[NSString alloc] initWithFormat:format arguments:va_arguments];
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:format arguments:va_arguments];
     va_end(va_arguments);
 
-    return [self where:condition];
+    return [self where:predicate];
 }
 
 + (NSArray *)where:(id)condition {


### PR DESCRIPTION
NSPredicate and NSString handles format differently.

For example, `[NSPredicate predicateWithFormat:@"name = [c] %@", name]` will automatically add quotation marks to embrace the `name`, but NSString doesn't.

This pull request is to let `whereFormat:` has the same behavior with NSPredicate.
