### PR TITLE
Use initial seed database when available

### DIFF
--- a/Classes/CoreDataManager.m
+++ b/Classes/CoreDataManager.m
@@ -122,6 +122,14 @@
     NSDictionary *options = @{ NSMigratePersistentStoresAutomaticallyOption: @YES,
                                NSInferMappingModelAutomaticallyOption: @YES };
 
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:[storeURL path]]) {
+        NSURL *defaultStoreURL = [[NSBundle mainBundle] URLForResource:[self databaseName] withExtension:nil];
+        if (defaultStoreURL) {
+            [fileManager copyItemAtURL:defaultStoreURL toURL:storeURL error:NULL];
+        }
+    }
+
     NSError *error = nil;
     if (![coordinator addPersistentStoreWithType:storeType configuration:nil URL:storeURL options:options error:&error])
         NSLog(@"ERROR WHILE CREATING PERSISTENT STORE COORDINATOR! %@, %@", error, [error userInfo]);


### PR DESCRIPTION
When seed database is available in Application bundle, use that to initialize the PersistentStore. When there is none, create a new one like now is the default.

Note; since I wanted to keep the _databaseName_ string, but the _.sqlite_  suffix gets slapped on; I've kept "withExtension" nil. 
