### PR TITLE
Fixed issue #23

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -174,7 +174,7 @@
     [request setPredicate:predicate];
     
     NSArray *fetchedObjects = [context executeFetchRequest:request error:nil];
-    return fetchedObjects.count > 0 ? fetchedObjects : nil;
+    return fetchedObjects;
 }
 
 - (BOOL)saveTheContext {


### PR DESCRIPTION
`+(NSArray*) where:(id)condition` returns an empty array instead of nil when no object were found.
