### PR TITLE
Support generic value transformation in mappings

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -173,6 +173,7 @@
     unless([attributes exists]) return;
 
     NSDictionary *transformed = [[self class] transformProperties:attributes withContext:self.managedObjectContext];
+
     for (NSString *key in transformed) [self willChangeValueForKey:key];
     [transformed each:^(NSString *key, id value) {
         [self setSafeValue:value forKey:key];

--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -173,7 +173,6 @@
     unless([attributes exists]) return;
 
     NSDictionary *transformed = [[self class] transformProperties:attributes withContext:self.managedObjectContext];
-
     for (NSString *key in transformed) [self willChangeValueForKey:key];
     [transformed each:^(NSString *key, id value) {
         [self setSafeValue:value forKey:key];

--- a/Classes/NSManagedObject+Mappings.m
+++ b/Classes/NSManagedObject+Mappings.m
@@ -24,6 +24,8 @@
 #import "NSManagedObject+ActiveRecord.h"
 #import "ObjectiveSugar.h"
 
+typedef id (^TransformBlock)(id value);
+
 @implementation NSManagedObject (Mappings)
 
 + (NSString *)keyForRemoteKey:(NSString *)remoteKey inContext:(NSManagedObjectContext *)context {
@@ -59,8 +61,13 @@
     if ([value isKindOfClass:class])
         return value;
 
-    if ([value isKindOfClass:[NSDictionary class]])
+    if ([value isKindOfClass:[NSDictionary class]]) {
+        if (value[@"transform"]) {
+            TransformBlock transformer = value[@"transform"];
+            return transformer(value);
+        }
         return [class findOrCreate:value inContext:context];
+    }
 
     if ([value isKindOfClass:[NSArray class]])
         return [NSSet setWithArray:[value map:^id(id object) {

--- a/Example/SampleProject.xcodeproj/xcshareddata/xcschemes/SampleProject.xcscheme
+++ b/Example/SampleProject.xcodeproj/xcshareddata/xcschemes/SampleProject.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "92C36FE96BF5420EBF7F892F"
+               BlueprintIdentifier = "B856C4C9923B4EC7A757D776"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "87598C52275746D1A1FE32AE"
+               BlueprintIdentifier = "8B11F5055ECD4BB49B3C08A4"
                BuildableName = "libPods-SampleProjectTests.a"
                BlueprintName = "Pods-SampleProjectTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Example/SampleProject/Models/Categories/Car+Mappings.m
+++ b/Example/SampleProject/Models/Categories/Car+Mappings.m
@@ -23,10 +23,12 @@
             @"class": [InsuranceCompany class]
         },
         @"insurance_company": @{
-                @"key": @"insuranceCompany",
-                @"class": [InsuranceCompany class]
-                }
-
+            @"key": @"insuranceCompany",
+            @"class": [InsuranceCompany class],
+            @"transform": ^id(NSDictionary * value) {
+                return [InsuranceCompany create:value];
+            }
+        }
     };
 }
 

--- a/Example/SampleProject/Models/Categories/Car+Mappings.m
+++ b/Example/SampleProject/Models/Categories/Car+Mappings.m
@@ -24,9 +24,10 @@
         },
         @"insurance_company": @{
             @"key": @"insuranceCompany",
-            @"class": [InsuranceCompany class],
-            @"transform": ^id(NSDictionary * value) {
-                return [InsuranceCompany create:value];
+            @"transform": ^id(NSDictionary *value, NSManagedObjectContext *context) {
+                InsuranceCompany * company = [InsuranceCompany findOrCreate:@{@"remoteID": value[@"id"] ?: value[@"remoteID"]} inContext:context];
+                [company update:value];
+                return company;
             }
         }
     };

--- a/Example/SampleProjectTests/MappingsTests.m
+++ b/Example/SampleProjectTests/MappingsTests.m
@@ -73,6 +73,11 @@ describe(@"Mappings", ^{
         Person *bob = [Person findOrCreate:@{ @"first_name": @"Bob" }];
         [[bob.firstName should] equal:@"Bob"];
     });
+
+    it(@"uses mappings to transform values", ^{
+        Car *car = [Car create:@{ @"hp": @150, @"insurance_company": @{ @"name" : @"Farmers", @"remoteID" : @4567 } }];
+        [[car.insuranceCompany.name should] equal:@"Farmers"];
+    });
     
     it(@"supports creating a parent object using just ID from the server", ^{
         Car *car = [Car create:@{ @"hp": @150, @"insurance_id": @1234 }];


### PR DESCRIPTION
## Changes
- Adds support for a `transform` key in mappings. It is expected to a block which will take the value and transform it as needed before being persisted.
## Side effects
- Implicit support for recursively finding and creating nested entities by defining them explicitly as transforms in model mappings (Fixes #60, simpler version of #62)
- Support for custom date formatters by specifying the date format and transforming the value in the block (Fixes #64, #46)
