### PR TITLE
Ignore unknown keys

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -335,14 +335,21 @@
 }
 
 - (void)setSafeValue:(id)value forKey:(id)key {
+    NSAttributeDescription *attribute = [[self entity] attributesByName][key];
 
-    if (value == nil || value == [NSNull null]) {
-        [self setPrimitiveValue:nil forKey:key];
+    if (attribute == nil && [[self entity] relationshipsByName][key] == nil) {
+#if DEBUG
+        NSLog(@"Could not set value ('%@') for key ('%@') on class ('%@'): No attribute or relationship found", value, key, NSStringFromClass([self class]));
+#endif
         return;
     }
 
-    NSDictionary *attributes = [[self entity] attributesByName];
-    NSAttributeType attributeType = [attributes[key] attributeType];
+    if (value == nil || value == [NSNull null]) {
+        [self setNilValueForKey:key];
+        return;
+    }
+
+    NSAttributeType attributeType = [attribute attributeType];
 
     if ((attributeType == NSStringAttributeType) && ([value isKindOfClass:[NSNumber class]]))
         value = [value stringValue];

--- a/Example/SampleProjectTests/MappingsTests.m
+++ b/Example/SampleProjectTests/MappingsTests.m
@@ -84,7 +84,12 @@ describe(@"Mappings", ^{
         Person *manager = [Person create:@{@"employees": @[employee]}];
         [[[manager should] have:1] employees];
     });
-    
+
+    it(@"ignores unknown keys", ^{
+        Car *car = [Car create];
+        [[car shouldNot] receive:@selector(setPrimitiveValue:forKey:)];
+        [car update:@{ @"chocolate": @"waffles" }];
+    });
 });
 
 SPEC_END


### PR DESCRIPTION
### Background

Currently, if a dictionary is passed to `update` and contains keys not present on the model, the system throws an exception. This can cause apps that already exist in production to crash if (for example) an API adds a new key and the key is not handled on the model object.
### Changes
- Adds a lightweight check for whether the model responds to the given key via `respondsToSelector`
