### PR TITLE
Chained fetch request builder (ObjectiveRelation)

### DIFF
--- a/Classes/NSManagedObject+ActiveRecord.h
+++ b/Classes/NSManagedObject+ActiveRecord.h
@@ -23,6 +23,7 @@
 + (id)create;
 + (id)create:(NSDictionary *)attributes;
 - (void)update:(NSDictionary *)attributes;
++ (void)updateAll:(NSDictionary *)attributes;
 
 + (instancetype)findOrCreate:(NSDictionary *)attributes;
 + (instancetype)find:(id)condition, ...;

--- a/Classes/NSManagedObject+ActiveRecord.h
+++ b/Classes/NSManagedObject+ActiveRecord.h
@@ -16,17 +16,7 @@
 
 @interface NSManagedObject (ActiveRecord)
 
-- (BOOL)save;
-- (void)delete;
-+ (void)deleteAll;
-
-+ (id)create;
-+ (id)create:(NSDictionary *)attributes;
-- (void)update:(NSDictionary *)attributes;
-+ (void)updateAll:(NSDictionary *)attributes;
-
-+ (instancetype)findOrCreate:(NSDictionary *)attributes;
-+ (instancetype)find:(id)condition, ...;
+#pragma mark - Fetch request building
 
 + (id)all;
 + (id)where:(id)condition, ...;
@@ -36,9 +26,30 @@
 + (id)offset:(NSUInteger)offset;
 + (id)inContext:(NSManagedObjectContext *)context;
 
-+ (instancetype)first;
-+ (instancetype)last;
+#pragma mark Counting
+
 + (NSUInteger)count;
+
+#pragma mark Plucking
+
++ (instancetype)firstObject;
++ (instancetype)lastObject;
+
++ (instancetype)find:(id)condition, ...;
+
+#pragma mark - Manipulating entities
+
++ (instancetype)findOrCreate:(NSDictionary *)properties;
+
++ (instancetype)create;
++ (instancetype)create:(NSDictionary *)attributes;
+
++ (void)updateAll:(NSDictionary *)attributes;
+- (void)update:(NSDictionary *)attributes;
+
+- (BOOL)save;
++ (void)deleteAll;
+- (void)delete;
 
 #pragma mark - Naming
 

--- a/Classes/NSManagedObject+ActiveRecord.h
+++ b/Classes/NSManagedObject+ActiveRecord.h
@@ -16,9 +16,6 @@
 
 @interface NSManagedObject (ActiveRecord)
 
-
-#pragma mark - Default Context
-
 - (BOOL)save;
 - (void)delete;
 + (void)deleteAll;
@@ -27,34 +24,20 @@
 + (id)create:(NSDictionary *)attributes;
 - (void)update:(NSDictionary *)attributes;
 
-+ (NSArray *)all;
-+ (NSArray *)allWithOrder:(id)order;
-+ (NSArray *)where:(id)condition, ...;
-+ (NSArray *)where:(id)condition order:(id)order;
-+ (NSArray *)where:(id)condition limit:(NSNumber *)limit;
-+ (NSArray *)where:(id)condition order:(id)order limit:(NSNumber *)limit;
 + (instancetype)findOrCreate:(NSDictionary *)attributes;
 + (instancetype)find:(id)condition, ...;
+
++ (id)all;
++ (id)where:(id)condition, ...;
++ (id)order:(id)condition;
++ (id)reverseOrder;
++ (id)limit:(NSUInteger)limit;
++ (id)offset:(NSUInteger)offset;
++ (id)inContext:(NSManagedObjectContext *)context;
+
++ (instancetype)first;
++ (instancetype)last;
 + (NSUInteger)count;
-+ (NSUInteger)countWhere:(id)condition, ...;
-
-#pragma mark - Custom Context
-
-+ (id)createInContext:(NSManagedObjectContext *)context;
-+ (id)create:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context;
-
-+ (void)deleteAllInContext:(NSManagedObjectContext *)context;
-
-+ (NSArray *)allInContext:(NSManagedObjectContext *)context;
-+ (NSArray *)allInContext:(NSManagedObjectContext *)context order:(id)order;
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context;
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order;
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context limit:(NSNumber *)limit;
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order limit:(NSNumber *)limit;
-+ (instancetype)findOrCreate:(NSDictionary *)properties inContext:(NSManagedObjectContext *)context;
-+ (instancetype)find:(id)condition inContext:(NSManagedObjectContext *)context;
-+ (NSUInteger)countInContext:(NSManagedObjectContext *)context;
-+ (NSUInteger)countWhere:(id)condition inContext:(NSManagedObjectContext *)context;
 
 #pragma mark - Naming
 

--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -8,6 +8,7 @@
 
 #import "NSManagedObject+ActiveRecord.h"
 #import "ObjectiveSugar.h"
+#import "ObjectiveRelation.h"
 
 @implementation NSManagedObjectContext (ActiveRecord)
 
@@ -17,144 +18,80 @@
 
 @end
 
-@implementation NSObject(null)
-
-- (BOOL)exists {
-    return self && self != [NSNull null];
-}
-
-@end
-
 @implementation NSManagedObject (ActiveRecord)
 
 #pragma mark - Finders
 
-+ (NSArray *)all {
-    return [self allInContext:[NSManagedObjectContext defaultContext]];
-}
-
-+ (NSArray *)allWithOrder:(id)order {
-    return [self allInContext:[NSManagedObjectContext defaultContext] order:order];
-}
-
-+ (NSArray *)allInContext:(NSManagedObjectContext *)context {
-    return [self allInContext:context order:nil];
-}
-
-+ (NSArray *)allInContext:(NSManagedObjectContext *)context order:(id)order {
-    return [self fetchWithCondition:nil inContext:context withOrder:order fetchLimit:nil];
-}
-
 + (instancetype)findOrCreate:(NSDictionary *)properties {
-    return [self findOrCreate:properties inContext:[NSManagedObjectContext defaultContext]];
-}
-
-+ (instancetype)findOrCreate:(NSDictionary *)properties inContext:(NSManagedObjectContext *)context {
-    NSManagedObject *existing = [self where:properties inContext:context].first;
-    return existing ?: [self create:properties inContext:context];
+    return [[self all] findOrCreate:properties];
 }
 
 + (instancetype)find:(id)condition, ... {
     va_list va_arguments;
     va_start(va_arguments, condition);
-    NSPredicate *predicate = [self predicateFromObject:condition arguments:va_arguments];
+    ObjectiveRelation *relation = [[self all] where:condition arguments:va_arguments];
     va_end(va_arguments);
 
-    return [self find:predicate inContext:[NSManagedObjectContext defaultContext]];
+    return [relation first];
 }
 
-+ (instancetype)find:(id)condition inContext:(NSManagedObjectContext *)context {
-    return [self where:condition inContext:context limit:@1].first;
-}
-
-+ (NSArray *)where:(id)condition, ... {
++ (id)where:(id)condition, ... {
     va_list va_arguments;
     va_start(va_arguments, condition);
-    NSPredicate *predicate = [self predicateFromObject:condition arguments:va_arguments];
+    ObjectiveRelation *relation = [[self all] where:condition arguments:va_arguments];
     va_end(va_arguments);
 
-    return [self where:predicate inContext:[NSManagedObjectContext defaultContext]];
+    return relation;
 }
 
-+ (NSArray *)where:(id)condition order:(id)order {
-    return [self where:condition inContext:[NSManagedObjectContext defaultContext] order:order];
++ (id)order:(id)order {
+    return [[self all] order:order];
 }
 
-+ (NSArray *)where:(id)condition limit:(NSNumber *)limit {
-    return [self where:condition inContext:[NSManagedObjectContext defaultContext] limit:limit];
++ (id)reverseOrder {
+    return [[self all] reverseOrder];
 }
 
-+ (NSArray *)where:(id)condition order:(id)order limit:(NSNumber *)limit {
-    return [self where:condition inContext:[NSManagedObjectContext defaultContext] order:order limit:limit];
++ (id)limit:(NSUInteger)limit {
+    return [[self all] limit:limit];
 }
 
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context {
-    return [self where:condition inContext:context order:nil limit:nil];
++ (id)offset:(NSUInteger)offset {
+    return [[self all] offset:offset];
 }
 
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order {
-    return [self where:condition inContext:context order:order limit:nil];
++ (id)inContext:(NSManagedObjectContext *)context {
+    return [[self all] inContext:context];
 }
 
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context limit:(NSNumber *)limit {
-    return [self where:condition inContext:context order:nil limit:limit];
++ (id)all {
+    return [ObjectiveRelation relationWithEntity:[self class]];
 }
 
-+ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order limit:(NSNumber *)limit {
-    return [self fetchWithCondition:condition inContext:context withOrder:order fetchLimit:limit];
++ (instancetype)first {
+    return [[self all] first];
 }
 
-#pragma mark - Aggregation
++ (instancetype)last {
+    return [[self all] last];
+}
 
 + (NSUInteger)count {
-    return [self countInContext:[NSManagedObjectContext defaultContext]];
-}
-
-+ (NSUInteger)countWhere:(id)condition, ... {
-    va_list va_arguments;
-    va_start(va_arguments, condition);
-    NSPredicate *predicate = [self predicateFromObject:condition arguments:va_arguments];
-    va_end(va_arguments);
-
-    return [self countWhere:predicate inContext:[NSManagedObjectContext defaultContext]];
-}
-
-+ (NSUInteger)countInContext:(NSManagedObjectContext *)context {
-    return [self countForFetchWithPredicate:nil inContext:context];
-}
-
-+ (NSUInteger)countWhere:(id)condition inContext:(NSManagedObjectContext *)context {
-    NSPredicate *predicate = [self predicateFromObject:condition];
-
-    return [self countForFetchWithPredicate:predicate inContext:context];
+    return [[self all] count];
 }
 
 #pragma mark - Creation / Deletion
 
 + (id)create {
-    return [self createInContext:[NSManagedObjectContext defaultContext]];
+    return [[self all] create];
 }
 
 + (id)create:(NSDictionary *)attributes {
-    return [self create:attributes inContext:[NSManagedObjectContext defaultContext]];
-}
-
-+ (id)create:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context {
-    unless([attributes exists]) return nil;
-
-    NSManagedObject *newEntity = [self createInContext:context];
-    [newEntity update:attributes];
-
-    return newEntity;
-}
-
-+ (id)createInContext:(NSManagedObjectContext *)context {
-    return [NSEntityDescription insertNewObjectForEntityForName:[self entityName]
-                                         inManagedObjectContext:context];
+    return [[self all] create:attributes];
 }
 
 - (void)update:(NSDictionary *)attributes {
-    unless([attributes exists]) return;
+    if (attributes == nil || (id)attributes == [NSNull null]) return;
 
     [attributes each:^(id key, id value) {
         id remoteKey = [self.class keyForRemoteKey:key];
@@ -170,119 +107,21 @@
     return [self saveTheContext];
 }
 
++ (void)deleteAll {
+    [[self all] deleteAll];
+}
+
 - (void)delete {
     [self.managedObjectContext deleteObject:self];
-}
-
-+ (void)deleteAll {
-    [self deleteAllInContext:[NSManagedObjectContext defaultContext]];
-}
-
-+ (void)deleteAllInContext:(NSManagedObjectContext *)context {
-    [[self allInContext:context] each:^(id object) {
-        [object delete];
-    }];
 }
 
 #pragma mark - Naming
 
 + (NSString *)entityName {
-
     return NSStringFromClass(self);
 }
 
 #pragma mark - Private
-
-+ (NSPredicate *)predicateFromDictionary:(NSDictionary *)dict {
-    NSArray *subpredicates = [dict map:^(id key, id value) {
-        return [NSPredicate predicateWithFormat:@"%K == %@", [self keyForRemoteKey:key], value];
-    }];
-
-    return [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
-}
-
-+ (NSPredicate *)predicateFromObject:(id)condition
-{
-    return [self predicateFromObject:condition arguments:NULL];
-}
-
-+ (NSPredicate *)predicateFromObject:(id)condition arguments:(va_list)arguments
-{
-    if ([condition isKindOfClass:[NSPredicate class]])
-        return condition;
-
-    if ([condition isKindOfClass:[NSString class]])
-        return [NSPredicate predicateWithFormat:condition arguments:arguments];
-
-    else if ([condition isKindOfClass:[NSDictionary class]])
-        return [self predicateFromDictionary:condition];
-
-    return nil;
-}
-
-+ (NSSortDescriptor *)sortDescriptorFromDictionary:(NSDictionary *)dict {
-    BOOL isAscending = ![[dict.allValues.first uppercaseString] isEqualToString:@"DESC"];
-    return [NSSortDescriptor sortDescriptorWithKey:dict.allKeys.first
-                                         ascending:isAscending];
-}
-
-+ (NSSortDescriptor *)sortDescriptorFromObject:(id)order {
-    if ([order isKindOfClass:[NSSortDescriptor class]])
-        return order;
-
-    else if ([order isKindOfClass:[NSString class]])
-        return [NSSortDescriptor sortDescriptorWithKey:order ascending:YES];
-
-    else if ([order isKindOfClass:[NSDictionary class]])
-        return [self sortDescriptorFromDictionary:order];
-
-    return nil;
-}
-
-+ (NSArray *)sortDescriptorsFromObject:(id)order {
-    if ([order isKindOfClass:[NSArray class]])
-        return [order map:^id (id object) {
-            return [self sortDescriptorFromObject:object];
-        }];
-
-    else
-        return @[[self sortDescriptorFromObject:order]];
-}
-
-+ (NSFetchRequest *)createFetchRequestInContext:(NSManagedObjectContext *)context {
-    NSFetchRequest *request = [NSFetchRequest new];
-    NSEntityDescription *entity = [NSEntityDescription entityForName:[self entityName]
-                                              inManagedObjectContext:context];
-    [request setEntity:entity];
-    return request;
-}
-
-+ (NSArray *)fetchWithCondition:(id)condition
-                      inContext:(NSManagedObjectContext *)context
-                      withOrder:(id)order
-                     fetchLimit:(NSNumber *)fetchLimit {
-
-    NSFetchRequest *request = [self createFetchRequestInContext:context];
-
-    if (condition)
-        [request setPredicate:[self predicateFromObject:condition]];
-
-    if (order)
-        [request setSortDescriptors:[self sortDescriptorsFromObject:order]];
-
-    if (fetchLimit)
-        [request setFetchLimit:[fetchLimit integerValue]];
-
-    return [context executeFetchRequest:request error:nil];
-}
-
-+ (NSUInteger)countForFetchWithPredicate:(NSPredicate *)predicate
-                               inContext:(NSManagedObjectContext *)context {
-    NSFetchRequest *request = [self createFetchRequestInContext:context];
-    [request setPredicate:predicate];
-
-    return [context countForFetchRequest:request error:nil];
-}
 
 - (BOOL)saveTheContext {
     if (self.managedObjectContext == nil ||
@@ -306,14 +145,14 @@
 
 - (id)objectOrSetOfObjectsFromValue:(id)value ofClass:(Class)class {
     if ([value isKindOfClass:[NSDictionary class]])
-        return [class findOrCreate:value inContext:self.managedObjectContext];
+        return [[class inContext:self.managedObjectContext] findOrCreate:value];
     
     else if ([value isKindOfClass:[NSArray class]])
         return [NSSet setWithArray:[value map:^id(NSDictionary *dict) {
-            return [class findOrCreate:dict inContext:self.managedObjectContext];
+            return [[class inContext:self.managedObjectContext] findOrCreate:dict];
         }]];
     else
-        return [class findOrCreate:@{ [class primaryKey]: value } inContext:self.managedObjectContext];
+        return [[class inContext:self.managedObjectContext] findOrCreate:@{ [class primaryKey]: value }];
 }
 
 - (void)setSafeValue:(id)value forKey:(id)key {

--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -90,6 +90,10 @@
     return [[self all] create:attributes];
 }
 
++ (void)updateAll:(NSDictionary *)attributes {
+    [[self all] updateAll:attributes];
+}
+
 - (void)update:(NSDictionary *)attributes {
     if (attributes == nil || (id)attributes == [NSNull null]) return;
 

--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -20,25 +20,16 @@
 
 @implementation NSManagedObject (ActiveRecord)
 
-#pragma mark - Finders
+#pragma mark - Fetch request building
 
-+ (instancetype)findOrCreate:(NSDictionary *)properties {
-    return [[self all] findOrCreate:properties];
-}
-
-+ (instancetype)find:(id)condition, ... {
-    va_list va_arguments;
-    va_start(va_arguments, condition);
-    ObjectiveRelation *relation = [[self all] where:condition arguments:va_arguments];
-    va_end(va_arguments);
-
-    return [relation first];
++ (id)all {
+    return [ObjectiveRelation relationWithEntity:[self class]];
 }
 
 + (id)where:(id)condition, ... {
     va_list va_arguments;
     va_start(va_arguments, condition);
-    ObjectiveRelation *relation = [[self all] where:condition arguments:va_arguments];
+    id relation = [[self all] where:condition arguments:va_arguments];
     va_end(va_arguments);
 
     return relation;
@@ -64,29 +55,42 @@
     return [[self all] inContext:context];
 }
 
-+ (id)all {
-    return [ObjectiveRelation relationWithEntity:[self class]];
-}
-
-+ (instancetype)first {
-    return [[self all] first];
-}
-
-+ (instancetype)last {
-    return [[self all] last];
-}
+#pragma mark Counting
 
 + (NSUInteger)count {
     return [[self all] count];
 }
 
-#pragma mark - Creation / Deletion
+#pragma mark Plucking
 
-+ (id)create {
++ (instancetype)firstObject {
+    return [[self all] firstObject];
+}
+
++ (instancetype)lastObject {
+    return [[self all] lastObject];
+}
+
++ (instancetype)find:(id)condition, ... {
+    va_list va_arguments;
+    va_start(va_arguments, condition);
+    id relation = [[self all] where:condition arguments:va_arguments];
+    va_end(va_arguments);
+
+    return [relation firstObject];
+}
+
+#pragma mark - Manipulating entities
+
++ (instancetype)findOrCreate:(NSDictionary *)properties {
+    return [[self all] findOrCreate:properties];
+}
+
++ (instancetype)create {
     return [[self all] create];
 }
 
-+ (id)create:(NSDictionary *)attributes {
++ (instancetype)create:(NSDictionary *)attributes {
     return [[self all] create:attributes];
 }
 

--- a/Classes/NSManagedObject+ActiveRecord_Compatibility.h
+++ b/Classes/NSManagedObject+ActiveRecord_Compatibility.h
@@ -1,0 +1,35 @@
+#import <CoreData/CoreData.h>
+
+@interface NSManagedObject (ActiveRecord_Compatibility)
+
+#pragma mark - Default context
+
++ (NSArray *)allWithOrder:(id)order __deprecated;
++ (NSArray *)where:(id)condition order:(id)order __deprecated;
++ (NSArray *)where:(id)condition limit:(NSNumber *)limit __deprecated;
++ (NSArray *)where:(id)condition order:(id)order limit:(NSNumber *)limit __deprecated;
+
++ (NSUInteger)countWhere:(id)condition, ... __deprecated;
+
++ (instancetype)first __deprecated;
++ (instancetype)last __deprecated;
+
+#pragma mark - Custom context
+
++ (NSArray *)allInContext:(NSManagedObjectContext *)context __deprecated;
++ (NSArray *)allInContext:(NSManagedObjectContext *)context order:(id)order __deprecated ;
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context __deprecated;
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order __deprecated;
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context limit:(NSNumber *)limit __deprecated;
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order limit:(NSNumber *)limit __deprecated;
+
++ (NSUInteger)countInContext:(NSManagedObjectContext *)context __deprecated;
++ (NSUInteger)countWhere:(id)condition inContext:(NSManagedObjectContext *)context __deprecated;
+
++ (instancetype)findOrCreate:(NSDictionary *)properties inContext:(NSManagedObjectContext *)context __deprecated;
++ (instancetype)find:(id)condition inContext:(NSManagedObjectContext *)context __deprecated;
++ (instancetype)createInContext:(NSManagedObjectContext *)context __deprecated;
++ (instancetype)create:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context __deprecated;
++ (void)deleteAllInContext:(NSManagedObjectContext *)context __deprecated;
+
+@end

--- a/Classes/NSManagedObject+ActiveRecord_Compatibility.m
+++ b/Classes/NSManagedObject+ActiveRecord_Compatibility.m
@@ -1,0 +1,96 @@
+#import "NSManagedObject+ActiveRecord_Compatibility.h"
+#import "NSManagedObject+ActiveRecord.h"
+#import "ObjectiveRelation.h"
+
+@implementation NSManagedObject (ActiveRecord_Compatibility)
+
+#pragma mark - Default context
+
++ (NSArray *)allWithOrder:(id)order {
+    return [[self order:order] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition order:(id)order {
+    return [[[self where:condition] order:order] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition limit:(NSNumber *)limit {
+    return [[[self where:condition] limit:[limit integerValue]] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition order:(id)order limit:(NSNumber *)limit {
+    return [[[[self where:condition] order:order] limit:[limit integerValue]] fetchedObjects];
+}
+
++ (NSUInteger)countWhere:(id)condition, ... {
+    va_list va_arguments;
+    va_start(va_arguments, condition);
+    id relation = [[self all] where:condition arguments:va_arguments];
+    va_end(va_arguments);
+
+    return [relation count];
+}
+
++ (instancetype)first {
+    return [[self all] firstObject];
+}
+
++ (instancetype)last {
+    return [[self all] lastObject];
+}
+
+#pragma mark - Custom context
+
++ (NSArray *)allInContext:(NSManagedObjectContext *)context {
+    return [[self inContext:context] fetchedObjects];
+}
+
++ (NSArray *)allInContext:(NSManagedObjectContext *)context order:(id)order {
+    return [[[self inContext:context] order:order] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context {
+    return [[[self inContext:context] where:condition] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order {
+    return [[[[self inContext:context] where:condition] order:order] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context limit:(NSNumber *)limit {
+    return [[[[self inContext:context] where:condition] limit:[limit integerValue]] fetchedObjects];
+}
+
++ (NSArray *)where:(id)condition inContext:(NSManagedObjectContext *)context order:(id)order limit:(NSNumber *)limit {
+    return [[[[[self inContext:context] where:condition] order:order] limit:[limit integerValue]] fetchedObjects];
+}
+
++ (NSUInteger)countInContext:(NSManagedObjectContext *)context {
+    return [[self inContext:context] count];
+}
+
++ (NSUInteger)countWhere:(id)condition inContext:(NSManagedObjectContext *)context {
+    return [[[self inContext:context] where:condition] count];
+}
+
++ (instancetype)findOrCreate:(NSDictionary *)properties inContext:(NSManagedObjectContext *)context {
+    return [[self inContext:context] findOrCreate:properties];
+}
+
++ (instancetype)find:(id)condition inContext:(NSManagedObjectContext *)context {
+    return [[self inContext:context] find:condition];
+}
+
++ (instancetype)createInContext:(NSManagedObjectContext *)context {
+    return [[self inContext:context] create];
+}
+
++ (instancetype)create:(NSDictionary *)attributes inContext:(NSManagedObjectContext *)context {
+    return [[self inContext:context] create:attributes];
+}
+
++ (void)deleteAllInContext:(NSManagedObjectContext *)context {
+    [[self inContext:context] deleteAll];
+}
+
+@end

--- a/Classes/ObjectiveRecord.h
+++ b/Classes/ObjectiveRecord.h
@@ -1,2 +1,3 @@
 #import "NSManagedObject+ActiveRecord.h"
+#import "NSManagedObject+ActiveRecord_Compatibility.h"
 #import "NSManagedObject+Mappings.h"

--- a/Classes/ObjectiveRelation.h
+++ b/Classes/ObjectiveRelation.h
@@ -12,7 +12,9 @@
 - (id)order:(id)condition;
 - (id)reverseOrder;
 - (id)limit:(NSUInteger)limit;
+@property (readonly, nonatomic) NSUInteger limit;
 - (id)offset:(NSUInteger)offset;
+@property (readonly, nonatomic) NSUInteger offset;
 - (id)inContext:(NSManagedObjectContext *)context;
 
 #pragma mark Counting

--- a/Classes/ObjectiveRelation.h
+++ b/Classes/ObjectiveRelation.h
@@ -2,15 +2,9 @@
 
 @interface ObjectiveRelation : NSObject <NSFastEnumeration>
 
-@property (readonly) NSArray *fetchedObjects;
-
 + (instancetype)relationWithEntity:(Class)entity;
 
-- (void)deleteAll;
-- (void)updateAll:(NSDictionary *)attributes;
-
-- (id)create;
-- (id)create:(NSDictionary *)attributes;
+#pragma mark - Fetch request building
 
 - (id)all;
 - (id)where:(id)condition, ...;
@@ -21,11 +15,25 @@
 - (id)offset:(NSUInteger)offset;
 - (id)inContext:(NSManagedObjectContext *)context;
 
-- (id)findOrCreate:(NSDictionary *)properties;
+#pragma mark Counting
+
+- (NSUInteger)count;
+
+#pragma mark Plucking
+
+- (id)firstObject;
+- (id)lastObject;
 - (id)find:(id)condition, ...;
 
-- (id)first;
-- (id)last;
-- (NSUInteger)count;
+#pragma mark - Manipulating entities
+
+- (id)findOrCreate:(NSDictionary *)properties;
+
+- (id)create;
+- (id)create:(NSDictionary *)attributes;
+
+- (void)updateAll:(NSDictionary *)attributes;
+
+- (void)deleteAll;
 
 @end

--- a/Classes/ObjectiveRelation.h
+++ b/Classes/ObjectiveRelation.h
@@ -7,6 +7,7 @@
 + (instancetype)relationWithEntity:(Class)entity;
 
 - (void)deleteAll;
+- (void)updateAll:(NSDictionary *)attributes;
 
 - (id)create;
 - (id)create:(NSDictionary *)attributes;

--- a/Classes/ObjectiveRelation.h
+++ b/Classes/ObjectiveRelation.h
@@ -1,0 +1,30 @@
+#import <Foundation/Foundation.h>
+
+@interface ObjectiveRelation : NSObject <NSFastEnumeration>
+
+@property (readonly) NSArray *fetchedObjects;
+
++ (instancetype)relationWithEntity:(Class)entity;
+
+- (void)deleteAll;
+
+- (id)create;
+- (id)create:(NSDictionary *)attributes;
+
+- (id)all;
+- (id)where:(id)condition, ...;
+- (id)where:(id)condition arguments:(va_list)arguments;
+- (id)order:(id)condition;
+- (id)reverseOrder;
+- (id)limit:(NSUInteger)limit;
+- (id)offset:(NSUInteger)offset;
+- (id)inContext:(NSManagedObjectContext *)context;
+
+- (id)findOrCreate:(NSDictionary *)properties;
+- (id)find:(id)condition, ...;
+
+- (id)first;
+- (id)last;
+- (NSUInteger)count;
+
+@end

--- a/Classes/ObjectiveRelation.m
+++ b/Classes/ObjectiveRelation.m
@@ -1,0 +1,241 @@
+#import "ObjectiveRelation.h"
+
+#import "ObjectiveSugar.h"
+
+#import "NSManagedObject+ActiveRecord.h"
+
+@interface ObjectiveRelation () <NSCopying> {
+    NSArray *_fetchedObjects;
+}
+
+@property (nonatomic, copy) NSArray *where;
+@property (nonatomic, copy) NSArray *order;
+@property (nonatomic) NSUInteger limit;
+@property (nonatomic) NSUInteger offset;
+
+@property (nonatomic, strong) Class entity;
+@property (nonatomic, strong) NSManagedObjectContext *managedObjectContext;
+
+@end
+
+@implementation ObjectiveRelation
+
++ (instancetype)relationWithEntity:(Class)entity {
+    ObjectiveRelation *relation = [self new];
+    relation.entity = entity;
+    return relation;
+}
+
+- (id)init {
+    if (self = [super init]) {
+        _where = @[];
+        _order = @[];
+        _managedObjectContext = [NSManagedObjectContext defaultContext];
+    }
+    return self;
+}
+
+- (id)where:(id)condition, ... {
+    va_list arguments;
+    va_start(arguments, condition);
+    ObjectiveRelation *relation = [self where:condition arguments:arguments];
+    va_end(arguments);
+
+    return relation;
+}
+
+- (id)where:(id)condition arguments:(va_list)arguments {
+    NSPredicate *predicate = [self predicateFromObject:condition arguments:arguments];
+    ObjectiveRelation *relation = [self copy];
+    relation.where = [relation.where arrayByAddingObject:predicate];
+    return relation;
+}
+
+- (id)order:(id)order {
+    ObjectiveRelation *relation = [self copy];
+    relation.order = [relation.order arrayByAddingObjectsFromArray:[self sortDescriptorsFromObject:order]];
+    return relation;
+}
+
+- (id)reverseOrder {
+    if ([self.order count] == 0) {
+        return [self order:@{[self.entity primaryKey]: @"DESC"}];
+    }
+
+    ObjectiveRelation *relation = [self copy];
+    relation.order = [relation.order valueForKey:NSStringFromSelector(@selector(reversedSortDescriptor))];
+    return relation;
+}
+
+- (id)limit:(NSUInteger)limit {
+    ObjectiveRelation *relation = [self copy];
+    relation.limit = limit;
+    return relation;
+}
+
+- (id)offset:(NSUInteger)offset {
+    ObjectiveRelation *relation = [self copy];
+    relation.offset = offset;
+    return relation;
+}
+
+- (id)inContext:(NSManagedObjectContext *)context {
+    ObjectiveRelation *relation = [self copy];
+    relation.managedObjectContext = context;
+    return relation;
+}
+
+- (NSUInteger)count {
+    return [self.managedObjectContext countForFetchRequest:[self prepareFetchRequest] error:nil];
+}
+
+- (instancetype)all {
+    return [self copy];
+}
+
+- (id)first {
+    return [[self limit:1] firstObject];
+}
+
+- (id)last {
+    return [[self reverseOrder] first];
+}
+
+- (id)find:(id)condition, ... {
+    va_list arguments;
+    va_start(arguments, condition);
+    ObjectiveRelation *relation = [self where:condition arguments:arguments];
+    va_end(arguments);
+
+    return [relation first];
+}
+
+- (id)create {
+    return [NSEntityDescription insertNewObjectForEntityForName:[self.entity entityName]
+                                         inManagedObjectContext:self.managedObjectContext];
+}
+
+- (id)create:(NSDictionary *)attributes {
+    if (attributes == nil || (id)attributes == [NSNull null]) return nil;
+
+    NSManagedObject *newEntity = [self create];
+    [newEntity update:attributes];
+    return newEntity;
+}
+
+- (id)findOrCreate:(NSDictionary *)properties {
+    return [[self where:properties] first] ?: [self create:properties];
+}
+
+- (void)deleteAll {
+    for (NSManagedObject *entity in self) {
+        [entity delete];
+    }
+}
+
+- (NSArray *)fetchedObjects {
+    if (_fetchedObjects == nil) {
+        _fetchedObjects = [self.managedObjectContext executeFetchRequest:[self prepareFetchRequest] error:nil];
+    }
+    return _fetchedObjects;
+}
+
+#pragma mark - NSObject
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<ObjectiveRelation where:%@ order:%@ limit:%d offset:%d context:%@>", self.where, self.order, self.limit, self.offset, self.managedObjectContext];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+    if ([NSArray instancesRespondToSelector:aSelector] && ![self respondsToSelector:aSelector]) {
+        return self.fetchedObjects;
+    }
+    return self;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    ObjectiveRelation *copy = [[self class] relationWithEntity:self.entity];
+    if (copy) {
+        copy.where = [self.where copyWithZone:zone];
+        copy.order = [self.order copyWithZone:zone];
+        copy.limit = self.limit;
+        copy.offset = self.offset;
+        copy.managedObjectContext = self.managedObjectContext;
+    }
+    return copy;
+}
+
+#pragma mark - NSFastEnumeration
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id [])buffer count:(NSUInteger)len {
+    return [self.fetchedObjects countByEnumeratingWithState:state objects:buffer count:len];
+}
+
+#pragma mark - Private
+
+- (NSFetchRequest *)prepareFetchRequest {
+    NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:[self.entity entityName]];
+    [fetchRequest setEntity:[NSEntityDescription entityForName:[self.entity entityName] inManagedObjectContext:self.managedObjectContext]];
+    [fetchRequest setFetchLimit:self.limit];
+    [fetchRequest setFetchOffset:self.offset];
+    [fetchRequest setPredicate:[NSCompoundPredicate andPredicateWithSubpredicates:self.where]];
+    [fetchRequest setSortDescriptors:self.order];
+    return fetchRequest;
+}
+
+- (NSPredicate *)predicateFromDictionary:(NSDictionary *)dict {
+    NSArray *subpredicates = [dict map:^(id key, id value) {
+        return [NSPredicate predicateWithFormat:@"%K == %@", [self.entity keyForRemoteKey:key], value];
+    }];
+
+    return [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+}
+
+- (NSPredicate *)predicateFromObject:(id)condition {
+    return [self predicateFromObject:condition arguments:NULL];
+}
+
+- (NSPredicate *)predicateFromObject:(id)condition arguments:(va_list)arguments {
+    if ([condition isKindOfClass:[NSPredicate class]])
+        return condition;
+
+    if ([condition isKindOfClass:[NSString class]])
+        return [NSPredicate predicateWithFormat:condition arguments:arguments];
+
+    if ([condition isKindOfClass:[NSDictionary class]])
+        return [self predicateFromDictionary:condition];
+
+    return nil;
+}
+
+- (NSSortDescriptor *)sortDescriptorFromDictionary:(NSDictionary *)dict {
+    BOOL isAscending = ![[dict.allValues.first uppercaseString] isEqualToString:@"DESC"];
+    return [NSSortDescriptor sortDescriptorWithKey:dict.allKeys.first ascending:isAscending];
+}
+
+- (NSSortDescriptor *)sortDescriptorFromObject:(id)order {
+    if ([order isKindOfClass:[NSSortDescriptor class]])
+        return order;
+
+    if ([order isKindOfClass:[NSString class]])
+        return [NSSortDescriptor sortDescriptorWithKey:order ascending:YES];
+
+    if ([order isKindOfClass:[NSDictionary class]])
+        return [self sortDescriptorFromDictionary:order];
+
+    return nil;
+}
+
+- (NSArray *)sortDescriptorsFromObject:(id)order {
+    if ([order isKindOfClass:[NSArray class]])
+        return [order map:^id (id object) {
+            return [self sortDescriptorFromObject:object];
+        }];
+
+    return @[[self sortDescriptorFromObject:order]];
+}
+
+@end

--- a/Classes/ObjectiveRelation.m
+++ b/Classes/ObjectiveRelation.m
@@ -35,10 +35,16 @@
     return self;
 }
 
+#pragma mark - Fetch request building
+
+- (id)all {
+    return [self copy];
+}
+
 - (id)where:(id)condition, ... {
     va_list arguments;
     va_start(arguments, condition);
-    ObjectiveRelation *relation = [self where:condition arguments:arguments];
+    id relation = [self where:condition arguments:arguments];
     va_end(arguments);
 
     return relation;
@@ -85,29 +91,35 @@
     return relation;
 }
 
+#pragma mark Counting
+
 - (NSUInteger)count {
     return [self.managedObjectContext countForFetchRequest:[self prepareFetchRequest] error:nil];
 }
 
-- (instancetype)all {
-    return [self copy];
+#pragma mark Plucking
+
+- (id)firstObject {
+    return [[[self limit:1] fetchedObjects] firstObject];
 }
 
-- (id)first {
-    return [[self limit:1] firstObject];
-}
-
-- (id)last {
-    return [[self reverseOrder] first];
+- (id)lastObject {
+    return [[self reverseOrder] firstObject];
 }
 
 - (id)find:(id)condition, ... {
     va_list arguments;
     va_start(arguments, condition);
-    ObjectiveRelation *relation = [self where:condition arguments:arguments];
+    id relation = [self where:condition arguments:arguments];
     va_end(arguments);
 
-    return [relation first];
+    return [relation firstObject];
+}
+
+#pragma mark - Manipulating entities
+
+- (id)findOrCreate:(NSDictionary *)properties {
+    return [[self where:properties] firstObject] ?: [self create:properties];
 }
 
 - (id)create {
@@ -123,10 +135,6 @@
     return newEntity;
 }
 
-- (id)findOrCreate:(NSDictionary *)properties {
-    return [[self where:properties] first] ?: [self create:properties];
-}
-
 - (void)updateAll:(NSDictionary *)attributes {
     for (NSManagedObject *entity in self) {
         [entity update:attributes];
@@ -137,13 +145,6 @@
     for (NSManagedObject *entity in self) {
         [entity delete];
     }
-}
-
-- (NSArray *)fetchedObjects {
-    if (_fetchedObjects == nil) {
-        _fetchedObjects = [self.managedObjectContext executeFetchRequest:[self prepareFetchRequest] error:nil];
-    }
-    return _fetchedObjects;
 }
 
 #pragma mark - NSObject
@@ -181,6 +182,13 @@
 }
 
 #pragma mark - Private
+
+- (NSArray *)fetchedObjects {
+    if (_fetchedObjects == nil) {
+        _fetchedObjects = [self.managedObjectContext executeFetchRequest:[self prepareFetchRequest] error:nil];
+    }
+    return _fetchedObjects;
+}
 
 - (NSFetchRequest *)prepareFetchRequest {
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:[self.entity entityName]];

--- a/Classes/ObjectiveRelation.m
+++ b/Classes/ObjectiveRelation.m
@@ -127,6 +127,12 @@
     return [[self where:properties] first] ?: [self create:properties];
 }
 
+- (void)updateAll:(NSDictionary *)attributes {
+    for (NSManagedObject *entity in self) {
+        [entity update:attributes];
+    }
+}
+
 - (void)deleteAll {
     for (NSManagedObject *entity in self) {
         [entity delete];

--- a/Example/SampleProjectTests/FindersAndCreatorsTests.m
+++ b/Example/SampleProjectTests/FindersAndCreatorsTests.m
@@ -11,6 +11,7 @@
 #import "Person+Mappings.h"
 #import "OBRPerson.h"
 #import "Car+Mappings.h"
+#import "ObjectiveRelation.h"
 
 static NSString *UNIQUE_NAME = @"ldkhbfaewlfbaewljfhb";
 static NSString *UNIQUE_SURNAME = @"laewfbaweljfbawlieufbawef";
@@ -19,9 +20,7 @@ static NSString *UNIQUE_SURNAME = @"laewfbaweljfbawlieufbawef";
 #pragma mark - Helpers
 
 Person *fetchUniquePerson() {
-    Person *person = [Person where:[NSString stringWithFormat:@"firstName = '%@' AND lastName = '%@'",
-                                    UNIQUE_NAME, UNIQUE_SURNAME]].first;
-    return person;
+    return [Person find:@"firstName = %@ AND lastName = %@", UNIQUE_NAME, UNIQUE_SURNAME];
 }
 
 NSManagedObjectContext *createNewContext() {
@@ -32,7 +31,7 @@ NSManagedObjectContext *createNewContext() {
 
 void createSomePeople(NSArray *names, NSArray *surnames, NSManagedObjectContext *context) {
     for (int i = 0; i < names.count; i++) {
-        Person *person = [Person createInContext:context];
+        Person *person = [[Person inContext:context] create];
         person.firstName = names[i];
         person.lastName = surnames[i];
         person.age = @(i);
@@ -63,32 +62,45 @@ describe(@"Find / Create / Save / Delete specs", ^{
 
         it(@"Finds using [Entity where: STRING]", ^{
 
-            Person *unique = [Person where:[NSPredicate predicateWithFormat:@"firstName == %@",UNIQUE_NAME]].first;
+            Person *unique = [[Person where:[NSString stringWithFormat:@"firstName == '%@'",UNIQUE_NAME]] first];
             [[unique.lastName should] equal:UNIQUE_SURNAME];
 
         });
 
         it(@"Finds using [Entity where: STRING and ARGUMENTS]", ^{
 
-            Person *unique = [Person where:@"firstName == %@", UNIQUE_NAME].first;
+            Person *unique = [[Person where:@"firstName == %@", UNIQUE_NAME] first];
             [[unique.lastName should] equal:UNIQUE_SURNAME];
 
         });
 
         it(@"Finds using [Entity where: DICTIONARY]", ^{
-            Person *person = [Person where:@{
+            Person *person = [[Person where:@{
                 @"firstName": @"John",
                 @"lastName": @"Doe",
                 @"age": @0,
                 @"isMember": @1,
                 @"anniversary": [NSDate dateWithTimeIntervalSince1970:0]
-            }].first;
+            }] first];
 
             [[person.firstName should] equal:@"John"];
             [[person.lastName should] equal:@"Doe"];
             [[person.age should] equal:@0];
             [[person.isMember should] equal:theValue(YES)];
             [[person.anniversary should] equal:[NSDate dateWithTimeIntervalSince1970:0]];
+        });
+
+        it(@"Finds using chained wheres", ^{
+            id query = [[[[[[Person where:@{@"firstName": @"John"}] where:@{@"lastName": @"Doe"}] where:@{@"lastName": @"Doe"}] where:@{@"age": @0}] where:@{@"isMember": @YES}] where:@{@"anniversary": [NSDate dateWithTimeIntervalSince1970:0] }];
+
+            Person *person = [query first];
+            [[person.firstName should] equal:@"John"];
+            [[person.lastName should] equal:@"Doe"];
+            [[person.age should] equal:@0];
+            [[person.isMember should] equal:theValue(YES)];
+            [[person.anniversary should] equal:[NSDate dateWithTimeIntervalSince1970:0]];
+
+            [[@([[query where:@"firstName = 'Stephen'"]count]) should] equal:@0];
         });
 
         it(@"Finds and creates if there was no object", ^{
@@ -132,11 +144,11 @@ describe(@"Find / Create / Save / Delete specs", ^{
                 newPerson.firstName = @"John";
                 [newPerson save];
             }];
-            [[[Person where:@{ @"firstName": @"John" } limit:@2] should] haveCountOf:2];
+            [[[[Person where:@{ @"firstName": @"John" }] limit:2] should] haveCountOf:2];
         });
     });
 
-    context(@"Ordering", ^{
+    context(@"Ordering and offseting", ^{
 
         id (^firstNameMapper)(Person *) = ^id (Person *p) { return p.firstName; };
         id (^lastNameMapper)(Person *) = ^id (Person *p) { return p.lastName; };
@@ -149,56 +161,73 @@ describe(@"Find / Create / Save / Delete specs", ^{
         });
 
         it(@"orders results by a single property", ^{
-            NSArray *resultLastNames = [[Person allWithOrder:@"lastName"]
+            NSArray *resultLastNames = [[Person order:@"lastName"]
                                         map:lastNameMapper];
             [[resultLastNames should] equal:@[@"Gaz", @"Mol", @"Mol", @"Zed"]];
         });
 
         it(@"orders results by multiple properties", ^{
-            NSArray *resultFirstNames = [[Person allWithOrder:@[@"lastName", @"firstName"]]
+            NSArray *resultFirstNames = [[Person order:@[@"lastName", @"firstName"]]
+                                         map:firstNameMapper];
+            [[resultFirstNames should] equal:@[@"Cal", @"Bob", @"Don", @"Abe"]];
+        });
+
+        it(@"orders results by chained properties", ^{
+            NSArray *resultFirstNames = [[[Person order:@"lastName"] order:@"firstName"]
                                          map:firstNameMapper];
             [[resultFirstNames should] equal:@[@"Cal", @"Bob", @"Don", @"Abe"]];
         });
 
         it(@"orders results by property ascending", ^{
-            NSArray *resultFirstNames = [[Person allWithOrder:@{@"firstName" : @"ASC"}]
+            NSArray *resultFirstNames = [[Person order:@{@"firstName" : @"ASC"}]
                                          map:firstNameMapper];
             [[resultFirstNames should] equal:@[@"Abe", @"Bob", @"Cal", @"Don"]];
         });
 
         it(@"orders results by property descending", ^{
-            NSArray *resultFirstNames = [[Person allWithOrder:@[@{@"firstName" : @"DESC"}]]
+            NSArray *resultFirstNames = [[Person order:@[@{@"firstName" : @"DESC"}]]
                                          map:firstNameMapper];
             [[resultFirstNames should] equal:@[@"Don", @"Cal", @"Bob", @"Abe"]];
         });
 
         it(@"orders results by sort descriptors", ^{
-            NSArray *resultFirstNames = [[Person allWithOrder:@[[NSSortDescriptor sortDescriptorWithKey:@"lastName" ascending:YES],
-                                                                [NSSortDescriptor sortDescriptorWithKey:@"firstName" ascending:NO]]]
+            NSArray *resultFirstNames = [[Person order:@[[NSSortDescriptor sortDescriptorWithKey:@"lastName" ascending:YES],
+                                                         [NSSortDescriptor sortDescriptorWithKey:@"firstName" ascending:NO]]]
                                          map:firstNameMapper];
             [[resultFirstNames should] equal:@[@"Cal", @"Don", @"Bob", @"Abe"]];
         });
 
         it(@"orders found results", ^{
-            NSArray *resultFirstNames = [[Person where:@{@"lastName" : @"Mol"} order:@"firstName"]
+            NSArray *resultFirstNames = [[[Person where:@{@"lastName" : @"Mol"}] order:@"firstName"]
                                          map:firstNameMapper];
             [[resultFirstNames should] equal:@[@"Bob", @"Don"]];
         });
 
         it(@"orders limited results", ^{
-            NSArray *resultLastNames = [[Person where:nil order:@"lastName" limit:@(2)]
+            NSArray *resultLastNames = [[[Person order:@"lastName"] limit:2]
                                         map:lastNameMapper];
             [[resultLastNames should] equal:@[@"Gaz", @"Mol"]];
         });
 
         it(@"orders found and limited results", ^{
-            NSArray *resultFirstNames = [[Person where:@{@"lastName" : @"Mol"}
-                                             inContext:[NSManagedObjectContext defaultContext]
+            NSArray *resultFirstNames = [[[[Person where:@{@"lastName" : @"Mol"}]
                                                  order:@[@{@"lastName" : @"ASC"},
-                                                         @{@"firstName" : @"DESC"}]
-                                                 limit:@(1)]
+                                                         @{@"firstName" : @"DESC"}]]
+                                                 limit:1]
                                          map:firstNameMapper];
             [[resultFirstNames should] equal:@[@"Don"]];
+        });
+
+        it(@"reverses order", ^{
+            NSArray *resultLastNames = [[[Person order:@"lastName"] reverseOrder]
+                                        map:lastNameMapper];
+            [[resultLastNames should] equal:@[@"Zed", @"Mol", @"Mol", @"Gaz"]];
+        });
+
+        it(@"offsets found results", ^{
+            NSArray *resultLastNames = [[[Person order:@"lastName"] offset:1]
+                                        map:lastNameMapper];
+            [[resultLastNames should] equal:@[@"Mol", @"Mol", @"Zed"]];
         });
     });
 
@@ -209,18 +238,13 @@ describe(@"Find / Create / Save / Delete specs", ^{
         });
 
         it(@"counts found entities", ^{
-            NSUInteger count = [Person countWhere:@{@"firstName" : @"Neo"}];
+            NSUInteger count = [[Person where:@{@"firstName" : @"Neo"}] count];
             [[@(count) should] equal:@(1)];
         });
 
         it(@"counts zero when none found", ^{
-            NSUInteger count = [Person countWhere:@{@"firstName" : @"Nobody"}];
+            NSUInteger count = [[Person where:@{@"firstName" : @"Nobody"}] count];
             [[@(count) should] equal:@(0)];
-        });
-
-        it(@"counts with variable arguments", ^{
-            NSUInteger count = [Person countWhere:@"firstName = %@", @"Neo"];
-            [[@(count) should] equal:@(1)];
         });
     });
 
@@ -230,7 +254,7 @@ describe(@"Find / Create / Save / Delete specs", ^{
             Person *person = [Person create];
             person.firstName = @"marin";
             person.lastName = UNIQUE_SURNAME;
-            [[[[Person where:@"firstName == 'marin'"].first lastName] should] equal:UNIQUE_SURNAME];
+            [[[[[Person where:@"firstName == 'marin'"] first] lastName] should] equal:UNIQUE_SURNAME];
         });
 
 
@@ -370,7 +394,7 @@ describe(@"Find / Create / Save / Delete specs", ^{
             newContext = createNewContext();
 
             [newContext performBlockAndWait:^{
-                Person *newPerson = [Person createInContext:newContext];
+                Person *newPerson = [[Person inContext:newContext] create];
                 newPerson.firstName = @"Joshua";
                 newPerson.lastName = @"Jobs";
                 newPerson.age = [NSNumber numberWithInt:100];
@@ -383,19 +407,19 @@ describe(@"Find / Create / Save / Delete specs", ^{
                                         andReturn:nil
                                     withArguments:@"Person", newContext];
 
-            [Person createInContext:newContext];
+            [[Person inContext:newContext] create];
         });
 
         it(@"Creates with dictionary in a separate context", ^{
             [[NSEntityDescription should] receive:@selector(insertNewObjectForEntityForName:inManagedObjectContext:)
                                     withArguments:@"Person", newContext];
 
-            [Person create:[NSDictionary dictionary] inContext:newContext];
+            [[Person inContext:newContext] create:[NSDictionary dictionary]];
         });
 
         it(@"Finds in a separate context", ^{
             [newContext performBlockAndWait:^{
-                Person *found = [Person where:@{ @"firstName": @"Joshua" } inContext:newContext].first;
+                Person *found = [[[Person where:@{ @"firstName": @"Joshua" }] inContext:newContext] first];
                 [[found.lastName should] equal:@"Jobs"];
             }];
         });
@@ -409,7 +433,7 @@ describe(@"Find / Create / Save / Delete specs", ^{
                 [NSManagedObjectContext.defaultContext save:nil];
 
                 createSomePeople(names, surnames, anotherContext);
-                newPeople = [Person allInContext:anotherContext];
+                newPeople = [Person inContext:anotherContext];
             }];
 
             [[newPeople should] haveCountOf:names.count];
@@ -418,36 +442,36 @@ describe(@"Find / Create / Save / Delete specs", ^{
         it(@"Finds the first match in a separate context", ^{
             NSDictionary *attributes = @{ @"firstName": @"Joshua",
                                           @"lastName": @"Jobs" };
-            Person *joshua = [Person find:attributes inContext:newContext];
+            Person *joshua = [[Person inContext:newContext] find:attributes];
             [[joshua.firstName should] equal:@"Joshua"];
         });
 
         it(@"Finds a limited number of results in a separate context", ^{
             [@4 times:^{
                 [newContext performBlockAndWait:^{
-                    Person *newPerson = [Person createInContext:newContext];
+                    Person *newPerson = [[Person inContext:newContext] create];
                     newPerson.firstName = @"Joshua";
                     [newPerson save];
                 }];
             }];
-            NSArray *people = [Person where:@{ @"firstName": @"Joshua"}
-                                  inContext:newContext
-                                      limit:@2];
+            NSArray *people = [[[Person where:@{ @"firstName": @"Joshua"}]
+                                  inContext:newContext]
+                                      limit:2];
             [[people should] haveCountOf:2];
         });
 
 
         it(@"Find or create in a separate context", ^{
             [newContext performBlockAndWait:^{
-                Person *luis = [Person findOrCreate:@{ @"firstName": @"Luis" } inContext:newContext];
+                Person *luis = [[Person inContext:newContext] findOrCreate:@{ @"firstName": @"Luis" }];
                 [[luis.firstName should] equal:@"Luis"];
             }];
         });
 
         it(@"Deletes all from context", ^{
             [newContext performBlockAndWait:^{
-                [Person deleteAllInContext:newContext];
-                [[[Person allInContext:newContext] should] beEmpty];
+                [[Person inContext:newContext] deleteAll];
+                [[[Person inContext:newContext] should] beEmpty];
             }];
         });
 
@@ -467,14 +491,14 @@ describe(@"Find / Create / Save / Delete specs", ^{
                                         andReturn:[NSEntityDescription entityForName:@"OtherPerson" inManagedObjectContext:newContext]
                                     withArguments:@"OtherPerson", newContext];
 
-            [OBRPerson allInContext:newContext];
+            [[OBRPerson inContext:newContext] fetchedObjects];
         });
 
         it(@"Creates the correct entity", ^{
             [[NSEntityDescription should] receive:@selector(insertNewObjectForEntityForName:inManagedObjectContext:)
                                     withArguments:@"OtherPerson", newContext];
 
-            [OBRPerson createInContext:newContext];
+            [[OBRPerson inContext:newContext] create];
         });
 
     });

--- a/Example/SampleProjectTests/FindersAndCreatorsTests.m
+++ b/Example/SampleProjectTests/FindersAndCreatorsTests.m
@@ -332,6 +332,26 @@ describe(@"Find / Create / Save / Delete specs", ^{
             }];
             [[[Person where:@{ @"firstName": @"asetnset" }] should] haveCountOf:1];
         });
+
+        it(@"updates multiple records", ^{
+            [Person deleteAll];
+            createSomePeople(@[@"Abe", @"Bob", @"Cal", @"Don"],
+                             @[@"Zed", @"Mol", @"Gaz", @"Mol"],
+                             [NSManagedObjectContext defaultContext]);
+            NSDictionary *query = @{ @"lastName" : @"Lee" };
+            [Person updateAll:query];
+            [[[Person where:query] should] haveCountOf:4];
+        });
+
+        it(@"updates multiple records through a query", ^{
+            [Person deleteAll];
+            createSomePeople(@[@"Abe", @"Bob", @"Cal", @"Don"],
+                             @[@"Zed", @"Mol", @"Gaz", @"Mol"],
+                             [NSManagedObjectContext defaultContext]);
+            NSDictionary *query = @{ @"lastName" : @"Lee" };
+            [[Person where:@"lastName = 'Mol'"] updateAll:query];
+            [[[Person where:query] should] haveCountOf:2];
+        });
     });
 
     context(@"Saving", ^{

--- a/Example/SampleProjectTests/MappingsTests.m
+++ b/Example/SampleProjectTests/MappingsTests.m
@@ -10,6 +10,7 @@
 #import "Person+Mappings.h"
 #import "Car+Mappings.h"
 #import "InsuranceCompany.h"
+#import "ObjectiveRelation.h"
 
 SPEC_BEGIN(MappingsTests)
 
@@ -43,11 +44,11 @@ describe(@"Mappings", ^{
     newContext.persistentStoreCoordinator = [[CoreDataManager sharedManager] persistentStoreCoordinator];
     
     beforeEach(^{
-        person = [Person create:JSON inContext:newContext];
+        person = [[Person inContext:newContext] create:JSON];
     });
     
     it(@"caches mappings", ^{
-        Car *car = [Car createInContext:newContext];
+        Car *car = [[Car inContext:newContext] create];
         [[Car should] receive:@selector(mappings) withCountAtMost:1];
         
         [car update:@{ @"hp": @150 }];

--- a/README.md
+++ b/README.md
@@ -55,23 +55,23 @@ NSArray *members = [Person where:membersPredicate];
 
 ``` objc
 // People by their last name ascending
-NSArray *sortedPeople = [Person allWithOrder:@"surname"];
+NSArray *sortedPeople = [Person order:@"surname"];
 
 // People named John by their last name Z to A
-NSArray *reversedPeople = [Person where:@{@"name" : @"John"} 
-                                  order:@{@"surname" : @"DESC"}];
+NSArray *reversedPeople = [[Person where:@{@"name" : @"John"}]
+                                   order:@{@"surname" : @"DESC"}];
 
 // You can use NSSortDescriptor too
-NSArray *people = [Person allWithOrder:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
+NSArray *people = [Person order:[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES]];
 
 // And multiple orderings with any of the above
-NSArray *morePeople = [Person allWithOrder:@[@{@"surname" : @"ASC"},
-                                             @{@"name" : @"DESC"}]];
+NSArray *morePeople = [Person order:@[@{@"surname" : @"ASC"},
+                                      @{@"name" : @"DESC"}]];
 
 // Just the first 5 people named John sorted by last name
-NSArray *fivePeople = [Person where:@"name == 'John'"
-                              order:@{@"surname" : @"ASC"}
-                              limit:@(5)];
+NSArray *fivePeople = [[[Person where:@"name == 'John'"]
+                                order:@"surname"]
+                                limit:5];
 ```
 
 #### Aggregation
@@ -81,7 +81,7 @@ NSArray *fivePeople = [Person where:@"name == 'John'"
 NSUInteger personCount = [Person count];
 
 // count people named John
-NSUInteger johnCount = [Person countWhere:@"name == 'John'"];
+NSUInteger johnCount = [[Person where:@"name == 'John'"] count];
 ```
 
 #### Custom ManagedObjectContext
@@ -90,9 +90,9 @@ NSUInteger johnCount = [Person countWhere:@"name == 'John'"];
 NSManagedObjectContext *newContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
 newContext.persistentStoreCoordinator = [[CoreDataManager instance] persistentStoreCoordinator];
 
-Person *john = [Person createInContext:newContext];
-Person *john = [Person find:@"name == 'John'" inContext:newContext];
-NSArray *people = [Person allInContext:newContext];
+Person *john = [[Person inContext:newContext] create];
+Person *john = [[Person inContext:newContext] find:@"name == 'John'"];
+id people = [Person inContext:newContext];
 ```
 
 #### Custom CoreData model or .sqlite database
@@ -106,13 +106,11 @@ If you've added the Core Data manually, you can change the custom model and data
 
 ``` objc
 // find
-[[Person all] each:^(Person *person) {
+for (Person *person in [Person all]) {
     person.member = @NO;
-}];
+};
 
-for(Person *person in [Person all]) {
-    person.member = @YES;
-}
+[[Person all] setValue:@YES forKey:@"member"];
 
 // create / save
 Person *john = [Person create];
@@ -121,9 +119,7 @@ john.surname = @"Wayne";
 [john save];
 
 // find / delete
-[[Person where: @{ "member" : @NO }] each:^(Person *person) {
-    [person delete];
-}];
+[[Person where:@{ "member" : @NO }] deleteAll];
 ```
 #### Mapping
 


### PR DESCRIPTION
This commit provides to ObjectiveRecord what [Arel](https://github.com/rails/arel) provided to Active Record.

It simplifies the interface by using a chained request builder. Instead of:

``` objective-c
[Person where:@{@"firstName": @"Stephen"} order:@"lastName" limit:@5];
```

We can use:

``` objective-c
[[[Person where:@"firstName = %@", @"Stephen"] order:@"lastName"] limit:5];
```

Because of chaining, we can remove most of the methods that build complex fetch requests all at once, and we can support features that were previously omitted, like offset (perhaps due to the number of method signature permutations required to make them work—especially with all the custom context methods).

Even `+countWhere:` can be removed:

``` objective-c
[[Person where:@"firstName = %@", @"Stephen"] count];
```

Each step in the chain returns a lazy-loaded fetch request. So you can hold onto a base request and build on it in different ways. E.g.,

``` objective-c
// Create 2 people in a private context
id privatePeople = [Person inContext:privateContext];
[privatePeople create:@{@"firstName": @"Marin"}];
[privatePeople create:@{@"firstName": @"Stephen"}];

// Pagination
id page = [Person limit:5];
// ...
page = [page offset:[page offset] + [page limit]];
```

A fetch request is not executed before you ask for data that would require a fetch, e.g. by iterating, fetching a specific result, or a count.

Fetch request builders conform to NSFastEnumeration and forward array selectors to the result set, so act on them as you would act on the final NSArray:

``` objective-c
for (Person *person in [Person all]) {
    // ...
}

[[Person where:@"admin = NO"] setValue:@YES forKey:@"admin"];
```

---

In addition to `-offset:`, `-reverseOrder` was easy to add.

There's a lot of flexibility here. We could (and should) consider adding things like:
- `-not` (which could build predicates using `+notPredicateWithSubpredicate:`)
- `-updateAll:` (simple wrapper that iterates over results and calls `-update:` on each one) _Edit: added this in another commit. It was easy._
### Considerations:
- Naming: `ObjectiveRelation` is like `ActiveRecord::Relation`, but we may want to consider a more conventional naming convention for custom classes here. Maybe something with a 3-character prefix?
- The `id` return values aren't ideal, but I couldn't figure out a better (and still simple) way of preventing Xcode from complaining that ObjectiveRelation objects didn't respond to NSArray selectors. Using `id`, however, means you can't call things like `.first` and `.count` on the return values without first casting them. We could, alternatively, return something like `id<ObjectiveRelation>`, but it was a bit verbosely ugly. Might be the direction to move, though. _Edit: toyed with this a bit, but conforming to a protocol immediately prevents the NSArray duck-typing._
- <del>**This is a breaking change!** Methods were removed, which we could still support (and deprecate) by rewriting them to be simple wrappers—may at least want a compatibility category that we can remove easily later. And return types have changed.</del> _Edit: added a compatibility category, imported by default for now._
- `-limit:` and `-offset:` take NSUInteger, not NSNumber. This just seemed more logical to me while typing out fetches manually, though I could see how something like the following would be desirable and may trump NSUInteger (though I think that if you're doing any math, primitives are the better way to go):
  
  ``` objective-c
  [[Person limit:parameters[@"limit"]] offset:parameters[@"offset"]];
  ```
