### PR TITLE
Ignore unknown keys in relationships

### DIFF
--- a/Example/SampleProjectTests/MappingsTests.m
+++ b/Example/SampleProjectTests/MappingsTests.m
@@ -90,6 +90,11 @@ describe(@"Mappings", ^{
         [[car shouldNot] receive:@selector(setPrimitiveValue:forKey:)];
         [car update:@{ @"chocolate": @"waffles" }];
     });
+
+    it(@"ignores unknown keys in relationships", ^{
+        Car *car = [Car create];
+        [car update:@{ @"owner": @{@"coolness" : @(100)} }];
+    });
 });
 
 SPEC_END


### PR DESCRIPTION
Inspired by pull request #67 : prevent crashs when API adds new keys in related objects by filtering the predicates dictionary.
