### PR TITLE
Handle mapping transformations in one place

### DIFF
--- a/Classes/NSManagedObject+Mappings.h
+++ b/Classes/NSManagedObject+Mappings.h
@@ -36,17 +36,29 @@
 
  @see +[NSManagedObject mappings]
 
- @param key A remote (server) attribute name.
+ @param key     A remote (server) attribute name.
+ @param context A local managed object context.
 
  @return A local (Core Data) attribute name.
  */
-+ (id)keyForRemoteKey:(NSString *)key;
++ (NSString *)keyForRemoteKey:(NSString *)remoteKey inContext:(NSManagedObjectContext *)context;
+
+/**
+ Transforms a given object for a remote attribute name.
+
+ @param value     Object to be transformed (e.g., a dictionary may become a managed object)
+ @param remoteKey A remote (server) attribute name.
+ @param context   A local managed object context.
+
+ @return A tranformed object.
+ */
++ (id)transformValue:(id)value forRemoteKey:(NSString *)remoteKey inContext:(NSManagedObjectContext *)context;
 
 /**
  The keypath uniquely identifying your entity. Usually an ID, e.g., @c @@"remoteID".
 
  @return An attribute name.
  */
-+ (id)primaryKey;
++ (NSString *)primaryKey;
 
 @end

--- a/Example/SampleProjectTests/MappingsTests.m
+++ b/Example/SampleProjectTests/MappingsTests.m
@@ -90,6 +90,13 @@ describe(@"Mappings", ^{
         [[car shouldNot] receive:@selector(setPrimitiveValue:forKey:)];
         [car update:@{ @"chocolate": @"waffles" }];
     });
+
+    it(@"ignores embedded unknown keys", ^{
+        [[theBlock(^{
+            Car *car = [Car create];
+            [car update:@{ @"owner": @{ @"coolness": @(100) } }];
+        }) shouldNot] raise];
+    });
 });
 
 SPEC_END


### PR DESCRIPTION
This pushes most of the transformation logic back into the Mappings category, and centralizes where properties are filtered in the ActiveRecord category.

Because of this, we can ensure that:
- transformations happen before KVC methods like `willChangeValueForKey:` and `didChangeValueForKey:` are called, and
- invalid keys are dropped before building a predicate for fetching via `findOrCreate:`.
