### PR TITLE
 ManagedObjectContext property in CoreDataManager

### DIFF
--- a/Classes/CoreDataManager.h
+++ b/Classes/CoreDataManager.h
@@ -25,7 +25,7 @@
 
 @interface CoreDataManager : NSObject
 
-@property (readonly, nonatomic) NSManagedObjectContext *managedObjectContext;
+@property (strong, nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (readonly, nonatomic) NSManagedObjectModel *managedObjectModel;
 @property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;
 

--- a/Example/SampleProject.xcodeproj/xcshareddata/xcschemes/SampleProject.xcscheme
+++ b/Example/SampleProject.xcodeproj/xcshareddata/xcschemes/SampleProject.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "321DCA4D7AEF437AB00D4390"
+               BlueprintIdentifier = "725FBA16121447FC862C9452"
                BuildableName = "libPods.a"
                BlueprintName = "Pods"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E8B7FE13184843A48E76BE6C"
+               BlueprintIdentifier = "D6EBB66D6B7C4F9C80919710"
                BuildableName = "libPods-SampleProjectTests.a"
                BlueprintName = "Pods-SampleProjectTests"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">

--- a/Example/SampleProjectTests/CoreDataManagerTests.m
+++ b/Example/SampleProjectTests/CoreDataManagerTests.m
@@ -42,7 +42,13 @@ describe(@"Core data stack", ^{
         NSPersistentStore *store = [manager.persistentStoreCoordinator persistentStores][0];
         [[store.URL.absoluteString should] endWithString:@".sqlite"];
     });
-    
+
+    it(@"permits to set custom ManagedObjectContext", ^{
+        NSManagedObjectContext *newContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+        manager.managedObjectContext = newContext;
+        [[manager.managedObjectContext should] equal:newContext];
+    });
+
 });
 
 SPEC_END


### PR DESCRIPTION
It's now settable from a client.
Basically I'm using ObjectiveRecord to unit testing an app using RestKit, which handles the ManagedObjectContext.
I added a Unit Test as well.
