### PR TITLE
Removed compiler warning

### DIFF
--- a/Classes/CoreDataManager.m
+++ b/Classes/CoreDataManager.m
@@ -22,10 +22,13 @@
 
 #import "CoreDataManager.h"
 
+@interface CoreDataManager()
+@property (nonatomic, strong, readwrite) NSManagedObjectContext *managedObjectContext;
+@property (nonatomic, strong, readwrite) NSManagedObjectModel *managedObjectModel;
+@property (nonatomic, strong, readwrite) NSPersistentStoreCoordinator *persistentStoreCoordinator;
+@end
+
 @implementation CoreDataManager
-@synthesize managedObjectContext = _managedObjectContext;
-@synthesize managedObjectModel = _managedObjectModel;
-@synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
 @synthesize databaseName = _databaseName;
 @synthesize modelName = _modelName;
 


### PR DESCRIPTION
"Accessor methods of synthesized property 'managedObjectModel' (etc) were overridden" 

Adding a readwrite property in a private category fixes this warning
