### PR TITLE
allow to set/override the default managed context

### DIFF
--- a/Classes/CoreDataManager.h
+++ b/Classes/CoreDataManager.h
@@ -25,6 +25,7 @@
 
 @interface CoreDataManager : NSObject
 
+@property (readwrite, strong, nonatomic) NSManagedObjectContext *defaultObjectContext;
 @property (readonly, nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (readonly, nonatomic) NSManagedObjectModel *managedObjectModel;
 @property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;

--- a/Classes/NSManagedObject+ActiveRecord.m
+++ b/Classes/NSManagedObject+ActiveRecord.m
@@ -26,7 +26,9 @@
 @implementation NSManagedObjectContext (ActiveRecord)
 
 + (NSManagedObjectContext *)defaultContext {
-    return [[CoreDataManager sharedManager] managedObjectContext];
+    if (CoreDataManager.sharedManager.defaultObjectContext)
+        return CoreDataManager.sharedManager.defaultObjectContext;
+    return CoreDataManager.sharedManager.managedObjectContext;
 }
 
 @end


### PR DESCRIPTION
More like a convinience not to specify "InContext" when calling:

```
- .all
- .find
- .where)
```
